### PR TITLE
HL-69

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -17,6 +17,7 @@ contract Vault is Ownable, IVault, ERC20PresetMinterPauser {
     IERC20Metadata private immutable _underlying;
     address private immutable _self;
     address private _market;
+    uint8 private immutable _decimals;
 
     constructor(
         IERC20Metadata underlying
@@ -33,6 +34,12 @@ contract Vault is Ownable, IVault, ERC20PresetMinterPauser {
 
         _self = address(this);
         _underlying = underlying;
+        _decimals = IERC20Metadata(underlying).decimals();
+    }
+
+    // Override decimals to be the same as the underlying asset
+    function decimals() public view override(ERC20, IERC20Metadata) returns (uint8) {
+        return _decimals;
     }
 
     function totalSupply()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "scripts": {
     "prepare": "husky install",
-    "postinstall": "npx hardhat compile",
     "hh:compile": "npx hardhat compile",
     "verify:uat": "npx hardhat --network goerli etherscan-verify",
     "deploy:uat": "npx hardhat clean && npx hardhat compile && npx hardhat deploy --network goerli --tags underlying,oracle,registryToken,vault,market --export ./exports/goerli.json && npx hardhat --network goerli etherscan-verify",

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -86,6 +86,11 @@ describe("Vault", () => {
 			vaultSymbol,
 			"Symbol should be same as underling with HL prefix"
 		).to.equal(`HL${underlyingSymbol}`);
+
+		const vaultDecimals = await vault.decimals();
+		expect(vaultDecimals, "Decimals should be same as underlying").to.equal(
+			underlyingDecimals
+		);
 	});
 
 	it("Should only allow owner to set market", async () => {


### PR DESCRIPTION
Fix: Vault now uses same decimals as underlying asset

