### PR TITLE
chore: Upgrade contracts to 0.8.15

### DIFF
--- a/contracts/HorseLink.sol
+++ b/contracts/HorseLink.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/IMarket.sol
+++ b/contracts/IMarket.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import "./SignatureLib.sol";
 

--- a/contracts/IMintable.sol
+++ b/contracts/IMintable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 // Horse.Link oracle interface
 interface IMintable {

--- a/contracts/IOracle.sol
+++ b/contracts/IOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import "./SignatureLib.sol";
 

--- a/contracts/IVault.sol
+++ b/contracts/IVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/interfaces/IERC4626.sol";

--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 pragma abicoder v2;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/MarketCurved.sol
+++ b/contracts/MarketCurved.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import "./Market.sol";
 import "./OddsLib.sol";

--- a/contracts/MarketOracle.sol
+++ b/contracts/MarketOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import "./IOracle.sol";
 import "./SignatureLib.sol";

--- a/contracts/MarketWithRisk.sol
+++ b/contracts/MarketWithRisk.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 pragma abicoder v2;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 contract Migrations {
     address public owner = msg.sender;

--- a/contracts/Mocks/MockToken.sol
+++ b/contracts/Mocks/MockToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/OddsLib.sol
+++ b/contracts/OddsLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import "@openzeppelin/contracts/utils/math/Math.sol";
 

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import "./IMarket.sol";
 import "./IVault.sol";

--- a/contracts/SignatureLib.sol
+++ b/contracts/SignatureLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 library SignatureLib {
     struct Signature {

--- a/contracts/TabOracle.sol
+++ b/contracts/TabOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.10;
+pragma solidity =0.8.15;
 
 import "@chainlink/contracts/src/v0.8/ChainlinkClient.sol";
 

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.15;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.15;
 import "./ERC4626Metadata.sol";
 import "./Market.sol";
 import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetMinterPauser.sol";

--- a/contracts/VaultTimeLock.sol
+++ b/contracts/VaultTimeLock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.15;
 import "./Vault.sol";
 import "hardhat/console.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -64,7 +64,7 @@ export default {
 	solidity: {
 		compilers: [
 			{
-				version: "0.8.10",
+				version: "0.8.15",
 				settings: {
 					optimizer: {
 						enabled: false,


### PR DESCRIPTION
https://dltx.atlassian.net/browse/HL-312

Changed contract pragma to Solidity 0.8.15, recompiled, ran tests successfully.
