### PR TITLE
fix: tests

### DIFF
--- a/deploy/030_Registry.ts
+++ b/deploy/030_Registry.ts
@@ -10,8 +10,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 	const { deploy } = deployments;
 	const namedAccounts = await getNamedAccounts();
 	const deployer = namedAccounts.deployer;
-	const registryTokenAddress =
-		namedAccounts.HorseLink ?? namedAccounts.MockHorseLink;
+	const registryTokenAddress = hre.network.live
+		? namedAccounts.HorseLink ?? namedAccounts.MockHorseLink
+		: (await hre.deployments.get("MockHorseLink")).address;
 
 	console.log(`Deployer: ${deployer}`);
 


### PR DESCRIPTION
 When running units tests, should use deployment "MockHorseLink" instead of named account for HorseLink/MockHorseLink.