### PR TITLE
Configurable settle script

### DIFF
--- a/config_dev_arbitrum.json
+++ b/config_dev_arbitrum.json
@@ -1,0 +1,7 @@
+{
+    "chainId": "42161",
+    "baseApiUrl": "https://dev2.horse.link/api",
+    "subgraphUrl": "https://api.thegraph.com/subgraphs/name/horse-link/hl-protocol-dev-arbitrum",
+    "privateKeyEnvVar": "ARBITRUM_DEPLOYER",
+    "providerUrlEnvVar": "ARBITRUM_URL"
+}

--- a/config_dev_goerli.json
+++ b/config_dev_goerli.json
@@ -1,0 +1,7 @@
+{
+    "chainId": "5",
+    "baseApiUrl": "https://dev2.horse.link/api",
+    "subgraphUrl": "https://api.thegraph.com/subgraphs/name/horse-link/hl-protocol-dev-goerli",
+    "privateKeyEnvVar": "GOERLI_DEPLOYER",
+    "providerUrl": "https://goerli.infura.io/v3/5a786545d1a342bd9ec378af10e316c2"
+}

--- a/config_dev_goerli.json
+++ b/config_dev_goerli.json
@@ -3,5 +3,5 @@
     "baseApiUrl": "https://dev2.horse.link/api",
     "subgraphUrl": "https://api.thegraph.com/subgraphs/name/horse-link/hl-protocol-dev-goerli",
     "privateKeyEnvVar": "GOERLI_DEPLOYER",
-    "providerUrl": "https://goerli.infura.io/v3/5a786545d1a342bd9ec378af10e316c2"
+    "providerUrlEnvVar": "GOERLI_URL"
 }

--- a/config_prod_arbitrum.json
+++ b/config_prod_arbitrum.json
@@ -1,0 +1,7 @@
+{
+    "chainId": "42161",
+    "baseApiUrl": "https://alpha.horse.link/api",
+    "subgraphUrl": "https://api.thegraph.com/subgraphs/name/horse-link/hl-protocol-arbitrum",
+    "privateKeyEnvVar": "ARBITRUM_DEPLOYER",
+    "providerUrlEnvVar": "ARBITRUM_URL"
+}

--- a/config_prod_goerli.json
+++ b/config_prod_goerli.json
@@ -1,0 +1,7 @@
+{
+    "chainId": "5",
+    "baseApiUrl": "https://alpha.horse.link/api",
+    "subgraphUrl": "https://api.thegraph.com/subgraphs/name/horse-link/hl-protocol-goerli",
+    "privateKeyEnvVar": "GOERLI_DEPLOYER",
+    "providerUrlEnvVar": "GOERLI_URL"
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
     "format": "prettier --write \"scripts/**/*.{js,ts}\" && prettier --write \"contracts/**/*.sol\"",
     "lint": "eslint --ext .ts --fix scripts && yarn format",
     "lint-staged": "lint-staged",
-    "scratch": "ts-node scripts/scratch.ts"
+    "scratch": "ts-node scripts/scratch.ts",
+    "settle:prod_goerli": "ts-node scripts/settle.ts prod_goerli",
+    "settle:dev_goerli": "ts-node scripts/settle.ts dev_goerli",
+    "settle:prod_arbitrum": "ts-node scripts/settle.ts prod_arbitrum",
+    "settle:dev_arbitrum": "ts-node scripts/settle.ts dev_arbitrum"
   },
   "dependencies": {
     "@chainlink/contracts": "^0.5.1",

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -8,9 +8,6 @@ import type { Signature } from "../scripts/utils";
 import { Market, Token, Vault } from "../build/typechain";
 import { prototype } from "events";
 
-export const node = process.env.GOERLI_URL;
-export const provider = new ethers.providers.JsonRpcProvider(node);
-
 // load .env into process.env
 dotenv.config();
 


### PR DESCRIPTION
Changes to allow the settle script to work on any deployment:

* Config file for each deployment
* Run settle script via yarn: `yarn settle:prod_arbitrum`
* Optionally include the number of hours back to look for unsettled bets as a parameter (defaults to 48 hours)

Config file contains info needed to call API for config, request bets via subgraph, access secrets for contract calls, eg:
```
{
    "chainId": "42161",
    "baseApiUrl": "https://dev2.horse.link/api",
    "subgraphUrl": "https://api.thegraph.com/subgraphs/name/horse-link/hl-protocol-dev-arbitrum",
    "privateKeyEnvVar": "ARBITRUM_DEPLOYER",
    "providerUrlEnvVar": "ARBITRUM_URL"
}
```